### PR TITLE
WorkerFactoryInterface::create() receives a second argument, the worker name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- WorkerFactoryInterface::create() receives a second argument, the worker name
+
 ## [0.1.0] - 2016-12-27
 Initial public release
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ The WorkerFactoryInterface that all worker factories must implement has
 a special method signature:
 
 ``` php
-public method create($workerEnvironment);
+public method create($workerEnvironment, $workerName);
 ```
 
 Your worker factories live outside of your code, but before they are asked

--- a/docs/examples/ExampleWorkerFactory.php
+++ b/docs/examples/ExampleWorkerFactory.php
@@ -20,9 +20,9 @@ class ExampleWorkerFactory implements WorkerFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($container)
+    public function create($container, $workerName)
     {
-        // return $container->get('foo_worker');
+        // return $container->get($workerName);
         return new ExampleWorker();
     }
 }

--- a/src/Worker/WorkerFactoryCollection.php
+++ b/src/Worker/WorkerFactoryCollection.php
@@ -82,7 +82,7 @@ class WorkerFactoryCollection implements WorkerFactoryCollectionInterface
         }
 
         $factory = $this->workerFactories[$workerName];
-        $worker = $factory->create($this->workerEnvironment);
+        $worker = $factory->create($this->workerEnvironment, $workerName);
 
         return $worker;
     }

--- a/src/Worker/WorkerFactoryInterface.php
+++ b/src/Worker/WorkerFactoryInterface.php
@@ -41,9 +41,10 @@ interface WorkerFactoryInterface
      *
      * @see WorkerFactoryCollectionInterface::registerWorkerEnvironmentSetup()
      * 
-     * @param mixed $workerEnvironment
+     * @param mixed  $workerEnvironment
+     * @param string $workerName
      *
      * @return WorkerInterface
      */
-    public function create($workerEnvironment);
+    public function create($workerEnvironment, $workerName);
 }

--- a/tests/unit/Worker/WorkerFactoryCollectionTest.php
+++ b/tests/unit/Worker/WorkerFactoryCollectionTest.php
@@ -62,7 +62,21 @@ class WorkerFactoryCollectionTest extends \PHPUnit_Framework_TestCase
 
         $workerFactory = m::mock(WorkerFactoryInterface::class)
             ->shouldReceive('create')
-            ->with(1)
+            ->with(1, anything())
+            ->getMock();
+        $this->wfc->addWorkerFactory(self::WORKER_NAME, $workerFactory);
+
+        $this->wfc->getWorker(self::WORKER_NAME);
+    }
+
+    public function testWorkerFactoryReceivesWorkerName()
+    {
+        $envSetup = new TestEnvironmentSetup();
+        $this->wfc->registerWorkerEnvironmentSetup([$envSetup, 'run']);
+
+        $workerFactory = m::mock(WorkerFactoryInterface::class)
+            ->shouldReceive('create')
+            ->with(anything(), self::WORKER_NAME)
             ->getMock();
         $this->wfc->addWorkerFactory(self::WORKER_NAME, $workerFactory);
 


### PR DESCRIPTION
It is not necessary anymore to create a new factory for each worker. Now there
can be one factory for multiple workers.